### PR TITLE
docs: document crate in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "mural-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dotenvy",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "mural-client"
 version = "0.2.1"
 edition = "2024"
 authors = ["Silvan Schmidt <mail@silvanschmidt.ch>"]
+description = "Client software for the mural wallpaper service"
+license = "MIT"
+license-file = "LICENSE"
+repository = "https://github.com/mural-sync/mural-client"
 
 
 [dependencies]


### PR DESCRIPTION
Adds fields like `license`, `repository` and `description` to `Cargo.toml`.