### PR TITLE
Add a basic CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +141,39 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "core-foundation"
@@ -547,6 +630,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,8 +775,9 @@ dependencies = [
 
 [[package]]
 name = "mural-client"
-version = "0.2.1"
+version = "1.1.1"
 dependencies = [
+ "clap",
  "dotenvy",
  "jiff",
  "reqwest",
@@ -1206,6 +1296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1636,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/mural-sync/mural-client"
 
 
 [dependencies]
+clap = { version = "4.5.32", features = ["cargo"] }
 dotenvy = "0.15.7"
 jiff = "0.2.4"
 reqwest = "0.12.15"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,16 @@
-use clap::Command;
+use std::path::PathBuf;
+
+use clap::{Arg, Command, value_parser};
 
 pub fn get_command() -> Command {
     Command::new(clap::crate_name!())
         .version(clap::crate_version!())
         .author(clap::crate_authors!())
         .about(clap::crate_description!())
+        .arg(
+            Arg::new("config-dir")
+                .long("config-dir")
+                .value_parser(value_parser!(PathBuf))
+                .help("provide a custom config directory"),
+        )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,8 @@
+use clap::Command;
+
+pub fn get_command() -> Command {
+    Command::new(clap::crate_name!())
+        .version(clap::crate_version!())
+        .author(clap::crate_authors!())
+        .about(clap::crate_description!())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,8 +13,10 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn load() -> Result<Self> {
-        let config_home_path = Self::config_home_path()?;
+    pub fn load(custom_config_dir: Option<&PathBuf>) -> Result<Self> {
+        let config_home_path = custom_config_dir
+            .map(|custom_config_dir| custom_config_dir.to_path_buf())
+            .unwrap_or(Self::config_home_path()?);
         let _ = std::fs::create_dir_all(&config_home_path);
         let config_file_path = config_home_path.join("config.toml");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod cli;
+
 mod config;
 pub(crate) use config::Config;
 
@@ -188,6 +190,8 @@ async fn update_wallpaper(
 
 pub async fn run() -> Result<()> {
     env::load_dotenv()?;
+
+    let _matches = cli::get_command().get_matches();
 
     let data_home_path = xdg::BaseDirectories::with_prefix("mural-client")
         .map_err(|_| Error::DataHome)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,8 @@ async fn update_wallpaper(
 pub async fn run() -> Result<()> {
     env::load_dotenv()?;
 
-    let _matches = cli::get_command().get_matches();
+    let matches = cli::get_command().get_matches();
+    let custom_config_dir = matches.get_one::<PathBuf>("config-dir");
 
     let data_home_path = xdg::BaseDirectories::with_prefix("mural-client")
         .map_err(|_| Error::DataHome)?
@@ -204,7 +205,7 @@ pub async fn run() -> Result<()> {
 
     loop {
         info!("updating wallpaper");
-        let config = Config::load()?;
+        let config = Config::load(custom_config_dir)?;
 
         last_digest = match update_wallpaper(&config, &wallpapers_path, &last_digest).await {
             Ok(new_digest) => new_digest,


### PR DESCRIPTION
This adds a basic cli to the `mural-client` command to set a custom config directory.
Fixes #23